### PR TITLE
Don't allow overlap line widths at high zooms

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "npm run build && sirv public --no-clear",
+    "start": "sirv public --no-clear",
     "deploy": "gh-pages -d public"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes https://github.com/stamen/mapbox-gl-style-design-system/issues/8

Evenly spaced lines in the design system view were overlapping when they became very wide.

This PR implements uneven spacing to account for lines at their widest to prevent overlap.

### Visuals

Before vs after below:

<img width="50%" src="https://user-images.githubusercontent.com/15698320/152020123-506bf1d3-c5fa-45d6-bebd-cbd9b7b0f0d3.png"/><img width="50%" src="https://user-images.githubusercontent.com/15698320/152019852-a7fceb28-9bf7-42cc-b163-62629fd00fac.png"/>

### QA: 
To QA this PR, you will need to build then start the repo!

~~`npm run build && npm run start`~~

~~If we want to just add the build to the start script let me know.~~ (edit: added build to start script, just run `npm run start`)

Also worth noting, you might experience caching (not due to this PR) in which case make sure you do a hard refresh (command + shift + R)

- [ ] Confirm that the chart still looks correct and the layers match up as expected (this should be the case)
- [ ] Confirm all style layers are still shown