### PR TITLE
Configure labels by layer

### DIFF
--- a/src/TypographyChart.svelte
+++ b/src/TypographyChart.svelte
@@ -75,13 +75,16 @@
     }
     const layerId = feature.layer.id;
     const layer = layers.filter(l => l.id === layerId)[0];
-    if (!layer) {
-      handleTooltipClose();
-      return;
-    }
+    const displayLayer = map.getStyle().layers.find(l => l.id === layerId);
 
     handleHoverTooltipClose();
     handleTooltipClose();
+
+    if (!layer) return;
+    if (displayLayer) {
+      const textField = displayLayer?.layout?.['text-field'];
+      labelText = Array.isArray(textField) && textField[0] === 'get' && textField[1] === 'label' ? feature?.properties?.label : textField;
+    }
 
     tooltip = {
       text: JSON.stringify({
@@ -380,7 +383,9 @@
 
   const updateSelectedLayerLabel = () => {
     if (selectedLayerId) {
-      map.setLayoutProperty(selectedLayerId, 'text-field', labelText);
+      let value = labelText;
+
+      map.setLayoutProperty(selectedLayerId, 'text-field', value);
     } 
     handleTooltipClose();
   };


### PR DESCRIPTION
Closes https://github.com/stamen/mapbox-gl-style-design-system/issues/26

This adds an `edit label` button to the tooltip to allow you to change the value in the shield label.

<img width="33%" src="https://user-images.githubusercontent.com/15698320/163838607-15868b3d-6d94-4c2c-9c5d-19a948211a73.png"/><img width="33%" src="https://user-images.githubusercontent.com/15698320/163838637-bc9d8d0f-cd73-41e8-8fab-851a07fce505.png"/><img width="33%" src="https://user-images.githubusercontent.com/15698320/163838657-37c972aa-44ca-4574-ae3a-a2ea15314218.png"/>


This is a pretty minimal implementation, but to me that seemed like the right move for now unless we can think of other similar things we'd want to be editing here. @ebrelsford let me know if you were thinking of something different here!

My thought is any other configuration a user might want to do here would likely be something they'd want to do in the stylesheet itself and we could focus on solutions like pulling from a live server to bring changes in faster.