### PR TITLE
Custom url

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "color": "^4.2.3",
     "computed-style-to-inline-style": "^3.0.0",
     "d3": "^7.1.1",
+    "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "lodash.throttle": "^4.1.1",

--- a/public/global.css
+++ b/public/global.css
@@ -59,6 +59,7 @@ button {
 
 button:disabled {
   color: #999;
+  pointer-events: none;
 }
 
 button:not(:disabled):active {

--- a/src/CustomUrlInput.svelte
+++ b/src/CustomUrlInput.svelte
@@ -1,0 +1,177 @@
+<script>
+  import { onDestroy, onMount, createEventDispatcher } from 'svelte';
+  import { fetchUrl } from './fetch-url';
+  import { shortcut } from './shortcut';
+  import { stylesEqual } from './styles/styles-equal';
+
+  const dispatch = createEventDispatcher();
+
+  export let activeStyle;
+  export let disabled = false;
+
+  let currentStyle;
+
+  let textInput = '';
+
+  let focused = false;
+  let error = null;
+
+  let allowPolling = true;
+
+  let selectedUrl = '';
+
+  onDestroy(() => {
+    // Cancel any polling in destroyed components
+    allowPolling = false;
+  });
+
+  // This will continue to poll/fetch the style at a local URL to allow live changes to be picked up
+  const poll = url => {
+    const pollCondition = str => {
+      if (!allowPolling || !str || selectedUrl !== str) return false;
+      if (!stylesEqual(currentStyle, activeStyle)) return false;
+      const absolutePathRegex = new RegExp('^(?:[a-z+]+:)?//', 'i');
+      return str.includes('localhost') || !absolutePathRegex.test(str);
+    };
+
+    // Simple polling for any style on localhost
+    // Check that should poll to set timer
+    if (pollCondition(url)) {
+      // Check poll condition again to cancel action for a url
+      setTimeout(() => pollCondition(url) && fetchStyle(url), 3000);
+    }
+  };
+
+  // Fetch the style json from the URL
+  const fetchStyle = async url => {
+    let style;
+    try {
+      const data = await fetchUrl(url);
+      // TODO make a better check that it is style and not arbitrary object
+      if (data && typeof data === 'object') {
+        // TODO create checks by type for non-mapbox maps
+        style = data;
+        poll(url);
+        currentStyle = style;
+        dispatch('styleload', { style });
+        return { status: '200' };
+      }
+    } catch (err) {
+      error = new Error('Style was not found.');
+      return { status: '404' };
+    }
+  };
+
+  // Change the URL by fetching the style and polling if necessary
+  const onChangeUrl = async url => {
+    const { status } = await fetchStyle(url);
+    if (status === '200') {
+      selectedUrl = url;
+      // Call poll after setting selectedUrl on success
+      poll(url);
+    }
+  };
+
+  // Submit URL from a custom or branch style
+  const submitUrl = async () => {
+    // Branch values always have an `id` field
+    let nextLocalUrl = textInput;
+
+    if (nextLocalUrl.includes('localhost')) {
+      const [preface, address] = nextLocalUrl.split('localhost');
+      // Fetch doesn't accept localhost unless prefaced with http://
+      // This adds the preface if not present
+      if (!preface) {
+        nextLocalUrl = `http://localhost${address}`;
+      }
+    }
+    onChangeUrl(nextLocalUrl);
+  };
+
+  const onKeySubmit = () => {
+    if (focused) {
+      submitUrl();
+    }
+  };
+
+  const handleOnFocus = () => {
+    focused = true;
+  };
+
+  const handleOnBlur = () => {
+    focused = false;
+    if (error) {
+      textInput = '';
+    }
+  };
+
+  const resetTextInput = () => {
+    if (!stylesEqual(currentStyle, activeStyle)) {
+      textInput = '';
+    }
+  };
+
+  const resetError = text => {
+    if (!error || text === undefined) return;
+    error = null;
+  };
+
+  // Reset error on beginning to type again
+  $: resetError(textInput);
+
+  $: {
+    activeStyle;
+    resetTextInput();
+  }
+</script>
+
+<div class="map-style-input">
+  {#if !!error}
+    <div class="error-message">
+      {error}
+    </div>
+  {/if}
+  <div class="custom-input">
+    <input
+      class:input-error={error}
+      bind:value={textInput}
+      on:focus={handleOnFocus}
+      on:blur={handleOnBlur}
+      placeholder={'enter a url to a style'}
+      {disabled}
+    />
+    <button
+      use:shortcut={{ code: 'Enter', callback: onKeySubmit }}
+      on:click={submitUrl}
+      disabled={selectedUrl === textInput || disabled}>Submit</button
+    >
+  </div>
+</div>
+
+<style>
+  .map-style-input {
+    margin-top: 6px;
+    display: flex;
+  }
+
+  .custom-input {
+    margin-top: 0px;
+  }
+
+  .input-error:focus {
+    outline: none;
+    border-color: red;
+  }
+
+  .error-message {
+    background-color: lightcoral;
+    border-style: solid;
+    border-color: red;
+    border-width: 1px;
+    border-radius: 4px;
+    padding: 6px;
+    color: white;
+    margin-right: 6px;
+    height: 18px;
+  }
+</style>

--- a/src/fetch-url.js
+++ b/src/fetch-url.js
@@ -1,0 +1,7 @@
+const fetchUrl = async url => {
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+};
+
+export { fetchUrl };

--- a/src/shortcut.js
+++ b/src/shortcut.js
@@ -1,0 +1,26 @@
+// See https://svelte.dev/repl/acd92c9726634ec7b3d8f5f759824d15?version=3.46.4 for more info
+export const shortcut = (node, params) => {
+  let handler;
+  const removeHandler = () => window.removeEventListener('keydown', handler),
+    setHandler = () => {
+      removeHandler();
+      if (!params) return;
+      handler = e => {
+        if (
+          !!params.alt != e.altKey ||
+          !!params.shift != e.shiftKey ||
+          !!params.control != (e.ctrlKey || e.metaKey) ||
+          params.code != e.code
+        )
+          return;
+        e.preventDefault();
+        params.callback ? params.callback() : node.click();
+      };
+      window.addEventListener('keydown', handler);
+    };
+  setHandler();
+  return {
+    update: setHandler,
+    destroy: removeHandler,
+  };
+};

--- a/src/styles/styles-equal.js
+++ b/src/styles/styles-equal.js
@@ -1,0 +1,15 @@
+import isEqual from 'lodash.isequal';
+import { migrate } from '@mapbox/mapbox-gl-style-spec';
+import { convertStylesheetToRgb } from '../convert-colors';
+
+const stylesEqual = (styleA, styleB) => {
+  if ((styleA && !styleB) || (styleB && !styleA)) return false;
+  if (!styleA && !styleB) return true;
+
+  styleA = convertStylesheetToRgb(migrate(styleA));
+  styleB = convertStylesheetToRgb(migrate(styleB));
+
+  return isEqual(styleA, styleB);
+};
+
+export { stylesEqual };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,6 +3656,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"


### PR DESCRIPTION
Closes https://github.com/stamen/chartographer/issues/33

Adds the ability to pull in a style from a URL. It also adds polling of that style if changes are made. @ebrelsford I know we discussed handling polling as a followup to this, but this reuses a lot of logic from Maperture and felt straight forward to leave in. If there's a lot of issues I didn't notice with polling, I'm open to removing and handling as followup instead.

### Review/QA

- [ ] Existing drop in style functionality works as expected
- [ ] Add a style via URL (try both clicking the button and `Enter` key to submit)
- [ ] Confirm style appears and url remains in text box
- [ ] Drop in a different style while that one is up
- [ ] Expect new style to appear and text box to go blank
- [ ] Add a locally hosted style via URL
- [ ] Expect this to look like any other style
- [ ] Make a change to the live style
- [ ] Expect chartographer to reload the style with changes
