### PR TITLE
Don't let tall rows of labels overlap

### DIFF
--- a/src/FillsChart.svelte
+++ b/src/FillsChart.svelte
@@ -80,9 +80,9 @@
       let placement = yScaleObj[l.id];
 
       // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
-      const numberOfLabelRows = layers[i - 1].id.split('/').length;
-      const prevLabelHeight = layers[i - 1]
-        ? Math.max(0, numberOfLabelRows - 1) * textMultiplier
+      const numberOfLabelRows = layers?.[i - 1]?.id?.split('/')?.length;
+      const prevLabelHeight = numberOfLabelRows
+        ? (numberOfLabelRows - 1) * textMultiplier
         : 0;
 
       yOffset += prevLabelHeight;

--- a/src/FillsChart.svelte
+++ b/src/FillsChart.svelte
@@ -78,13 +78,20 @@
       const l = layers[i];
       const textMultiplier = 18;
       let placement = yScaleObj[l.id];
+
       // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
       const prevLabelHeight = layers[i - 1]
         ? Math.max(0, layers[i - 1].id.split('/').length - 1) * textMultiplier
         : 0;
+
       yOffset += prevLabelHeight;
+
       const nextPlacement = placement + yOffset;
+
       yScaleObj[l.id] = nextPlacement;
+
+      // For the last layer, add additional space since there isn't
+      // a subsequent layer to add it from the previous
       if (i === layers.length - 1) {
         yOffset += l.id.split('/').length * textMultiplier;
       }

--- a/src/FillsChart.svelte
+++ b/src/FillsChart.svelte
@@ -80,8 +80,9 @@
       let placement = yScaleObj[l.id];
 
       // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
+      const numberOfLabelRows = layers[i - 1].id.split('/').length;
       const prevLabelHeight = layers[i - 1]
-        ? Math.max(0, layers[i - 1].id.split('/').length - 1) * textMultiplier
+        ? Math.max(0, numberOfLabelRows - 1) * textMultiplier
         : 0;
 
       yOffset += prevLabelHeight;

--- a/src/FillsChart.svelte
+++ b/src/FillsChart.svelte
@@ -76,17 +76,17 @@
 
     for (let i = 0; i < layers.length; i++) {
       const l = layers[i];
-      const multiplier = 18;
+      const textMultiplier = 18;
       let placement = yScaleObj[l.id];
       // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
       const prevLabelHeight = layers[i - 1]
-        ? Math.max(0, layers[i - 1].id.split('/').length - 1) * multiplier
+        ? Math.max(0, layers[i - 1].id.split('/').length - 1) * textMultiplier
         : 0;
       yOffset += prevLabelHeight;
       const nextPlacement = placement + yOffset;
       yScaleObj[l.id] = nextPlacement;
       if (i === layers.length - 1) {
-        yOffset += l.id.split('/').length * multiplier;
+        yOffset += l.id.split('/').length * textMultiplier;
       }
     }
 

--- a/src/FillsChart.svelte
+++ b/src/FillsChart.svelte
@@ -22,6 +22,7 @@
 
   let chartHeight = $svgStore?.fills?.chartHeight;
   let yScale = $svgStore?.fills?.yScale;
+  let adjustedYScale = $svgStore?.fills?.adjustedYScale;
 
   let gradients = $svgStore?.fills?.gradients ?? [];
   let svgLayers = $svgStore?.fills?.svgs ?? [];
@@ -65,6 +66,36 @@
       )
       .padding(0.25);
 
+    // Adjust the yScale to account for layer width since D3 scaleBand spaces evenly
+    const yScaleObj = layers.reduce((acc, l) => {
+      acc[l.id] = yScale(l.id);
+      return acc;
+    }, {});
+
+    let yOffset = 0;
+
+    for (let i = 0; i < layers.length; i++) {
+      const l = layers[i];
+      const multiplier = 18;
+      let placement = yScaleObj[l.id];
+      // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
+      const prevLabelHeight = layers[i - 1]
+        ? Math.max(0, layers[i - 1].id.split('/').length - 1) * multiplier
+        : 0;
+      yOffset += prevLabelHeight;
+      const nextPlacement = placement + yOffset;
+      yScaleObj[l.id] = nextPlacement;
+      if (i === layers.length - 1) {
+        yOffset += l.id.split('/').length * multiplier;
+      }
+    }
+
+    // Adjust the height to account for the increased offsets
+    chartHeight = chartHeight + yOffset;
+
+    // Adjusted yScale function to use throughout
+    adjustedYScale = layerId => yScaleObj[layerId];
+
     const getDrawLayer = layer => {
       const { color: layerColor, gradients: layerGradients } = getColor(
         layer,
@@ -85,10 +116,10 @@
     layers = layers.map(getDrawLayer);
 
     // TODO consider combining casing with roads
-    svgLayers = layers.map(d => {
+    svgLayers = layers.map((d, i) => {
       return {
         x: xScale(d.minzoom || MIN_ZOOM),
-        y: yScale(d.id),
+        y: adjustedYScale(d.id),
         height: yScale.bandwidth(),
         width: xScale(d.maxzoom || MAX_ZOOM) - xScale(d.minzoom || MIN_ZOOM),
         fill: d.fill,
@@ -109,6 +140,7 @@
         gradients,
         chartHeight,
         yScale,
+        adjustedYScale,
       },
     }));
 
@@ -129,7 +161,7 @@
     tooltip = {
       text: JSON.stringify(layer.paint, null, 2),
       left: xScale(MAX_ZOOM) + 10,
-      top: yScale(layer.id) + yScale.bandwidth(),
+      top: adjustedYScale(layer.id) + yScale.bandwidth(),
     };
   }
 
@@ -137,7 +169,7 @@
     tooltip = {
       text: `${layerId} had too many possible property/value combinations and has been limited to showing ${$propertyValueComboLimitStore} for performance.`,
       left: 24,
-      top: yScale(expandedLayerId) + yScale.bandwidth() * 0.75,
+      top: adjustedYScale(expandedLayerId) + yScale.bandwidth() * 0.75,
     };
   }
 
@@ -211,7 +243,7 @@
             class="y-axis tick"
             opacity="1"
             transform="translate(0,
-        {yScale(rect.layer.id) + yScale.bandwidth() / 2})"
+        {adjustedYScale(rect.layer.id) + yScale.bandwidth() / 2})"
           >
             {#each rect.layer.id.split('/') as idSection, i}<g>
                 {#if i === 0 && limitHit.includes(idSection)}

--- a/src/LinesChart.svelte
+++ b/src/LinesChart.svelte
@@ -238,9 +238,9 @@
 
       const textMultiplier = 18;
       // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
-      const numberOfLabelRows = layers[i - 1].id.split('/').length;
-      const prevLabelHeight = layers[i - 1]
-        ? Math.max(0, numberOfLabelRows - 1) * textMultiplier
+      const numberOfLabelRows = layers?.[i - 1]?.id?.split('/')?.length;
+      const prevLabelHeight = numberOfLabelRows
+        ? (numberOfLabelRows - 1) * textMultiplier
         : 0;
 
       if (prevLabelHeight > currentLineWidth) {

--- a/src/LinesChart.svelte
+++ b/src/LinesChart.svelte
@@ -238,7 +238,7 @@
 
       const textMultiplier = 18;
       // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
-      const numberOfLabelRows = layers?.[i - 1]?.id?.split('/')?.length;
+      const numberOfLabelRows = lineLayers?.[i - 1]?.id?.split('/')?.length;
       const prevLabelHeight = numberOfLabelRows
         ? (numberOfLabelRows - 1) * textMultiplier
         : 0;

--- a/src/LinesChart.svelte
+++ b/src/LinesChart.svelte
@@ -238,9 +238,9 @@
 
       const textMultiplier = 18;
       // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
-      const prevLabelHeight = lineLayers[i - 1]
-        ? Math.max(0, lineLayers[i - 1].id.split('/').length - 1) *
-          textMultiplier
+      const numberOfLabelRows = layers[i - 1].id.split('/').length;
+      const prevLabelHeight = layers[i - 1]
+        ? Math.max(0, numberOfLabelRows - 1) * textMultiplier
         : 0;
 
       if (prevLabelHeight > currentLineWidth) {

--- a/src/LinesChart.svelte
+++ b/src/LinesChart.svelte
@@ -252,6 +252,8 @@
       const nextPlacement = placement + yOffset;
       yScaleObj[l.id] = nextPlacement;
 
+      // For the last layer, add additional space since there isn't
+      // a subsequent layer to add it from the previous
       if (i === lineLayers.length - 1) {
         yOffset += l.id.split('/').length * textMultiplier;
       }

--- a/src/LinesChart.svelte
+++ b/src/LinesChart.svelte
@@ -231,10 +231,30 @@
       const prevLineWidth = lineLayers[i - 1]
         ? getFullLineWidth(lineLayers[i - 1])
         : 1;
+
+      yOffset += prevLineWidth / 2;
+
       const currentLineWidth = getFullLineWidth(l);
-      yOffset += prevLineWidth / 2 + currentLineWidth / 2;
+
+      const textMultiplier = 18;
+      // Determine the previous label height by splitting the id up as it will be stacked and multiplying by text height
+      const prevLabelHeight = lineLayers[i - 1]
+        ? Math.max(0, lineLayers[i - 1].id.split('/').length - 1) *
+          textMultiplier
+        : 0;
+
+      if (prevLabelHeight > currentLineWidth) {
+        yOffset += prevLabelHeight;
+      } else {
+        yOffset += currentLineWidth / 2;
+      }
+
       const nextPlacement = placement + yOffset;
       yScaleObj[l.id] = nextPlacement;
+
+      if (i === lineLayers.length - 1) {
+        yOffset += l.id.split('/').length * textMultiplier;
+      }
     }
 
     // Adjust the height to account for the increased offsets

--- a/src/stores.js
+++ b/src/stores.js
@@ -18,6 +18,7 @@ export const svgStoreInitialState = {
     gradients: [],
     chartHeight: null,
     yScale: null,
+    adjustedYScale: null,
   },
   lines: {
     background: null,


### PR DESCRIPTION
Closes https://github.com/stamen/chartographer/issues/44

This PR makes the layer visualizations take into account label height so that labels don't overlap when there are many properties.

For lines, this is combined with logic to separate out visualizations by line width, so that the next label will come after either the label or line SVG path depending on which has more height.

### Before and after
<img width="50%" src="https://user-images.githubusercontent.com/15698320/208201078-94d82fac-1ca0-4279-b191-56d190dcb22c.png"/><img width="50%" src="https://user-images.githubusercontent.com/15698320/208201038-431b3fea-ec5b-409d-8ada-e17b21924f33.png"/>


I think there's room to break out some more of this similar logic to be less duplicative still, but it may be worth doing as a followup since this solves for the bug and the behavior is slightly different between fills and lines.