### PR TITLE
Maplibre/Mapbox switch on typography chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Add a switch to Typography chart to switch renderer from Mapbox to Maplibre
+
 ## 1.0.0
 
 - Change name to Chartographer

--- a/example-styles/osm-liberty-maplibre.json
+++ b/example-styles/osm-liberty-maplibre.json
@@ -1193,7 +1193,8 @@
       "filter": ["==", "oneway", 1],
       "layout": {
         "icon-image": "arrow",
-        "symbol-placement": "line"
+        "symbol-placement": "line",
+        "text-overlap": "never"
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+    "@maplibre/maplibre-gl-style-spec": "^17.0.2",
     "cartesian": "^1.0.1",
     "color": "^4.2.3",
     "computed-style-to-inline-style": "^3.0.0",
@@ -52,6 +53,7 @@
     "mapbox-expression": "^0.0.3",
     "mapbox-gl": "^1.13.2",
     "mapbox-gl-style-recurse": "github:stamen/mapbox-gl-style-recurse",
+    "maplibre-gl": "^2.4.0",
     "sirv-cli": "^1.0.0",
     "svelte-fa": "^2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-    "@maplibre/maplibre-gl-style-spec": "^17.0.2",
+    "@maplibre/maplibre-gl-style-spec": "^16.0.0",
     "cartesian": "^1.0.1",
     "color": "^4.2.3",
     "computed-style-to-inline-style": "^3.0.0",

--- a/public/global.css
+++ b/public/global.css
@@ -40,7 +40,7 @@ textarea {
   font-size: inherit;
   -webkit-padding: 0.4em 0;
   padding: 0.4em;
-  margin: 0 0 0.5em 0;
+  margin: 0 0 0 0;
   box-sizing: border-box;
   border: 1px solid #ccc;
   border-radius: 2px;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,6 +41,7 @@ export default {
     format: 'iife',
     name: 'app',
     file: 'public/build/bundle.js',
+    inlineDynamicImports: true,
   },
   plugins: [
     svelte({

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,8 +1,10 @@
 <script>
   import * as d3 from 'd3';
-  import { migrate as migrateMapbox } from '@mapbox/mapbox-gl-style-spec';
+  import {
+    migrate as migrateMapbox,
+    validate,
+  } from '@mapbox/mapbox-gl-style-spec';
   import { migrate as migrateMaplibre } from '@maplibre/maplibre-gl-style-spec';
-
   import { onMount } from 'svelte';
   import Fa from 'svelte-fa/src/fa.svelte';
   import { faTrash, faDownload } from '@fortawesome/free-solid-svg-icons';
@@ -20,6 +22,7 @@
     displayLayersStoreInitialState,
     svgStore,
     svgStoreInitialState,
+    styleStore,
   } from './stores';
   import ExpandLayersWorker from 'web-worker:./expand-layers-worker.js';
   import { stylesEqual } from './styles/styles-equal';
@@ -166,6 +169,8 @@
     if (stylesEqual(style, nextStyle)) return;
     setStyle(nextStyle);
   };
+
+  $: styleStore.set(style);
 </script>
 
 <main

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,6 +21,7 @@
   } from './stores';
   import ExpandLayersWorker from 'web-worker:./expand-layers-worker.js';
   import { stylesEqual } from './styles/styles-equal';
+  import RendererSelect from './RendererSelect.svelte';
 
   export let selectedTab;
   export let style;
@@ -173,12 +174,19 @@
     {:else}
       <div />
     {/if}
-    <div class="custom-url-input">
-      <CustomUrlInput
-        on:styleload={handleCustomUrl}
-        activeStyle={style}
-        disabled={isLoading && loadingProgress !== null}
-      />
+    <div class="right-side-container">
+      {#if selectedTab === 'typography'}
+        <div class="renderer-switch-container">
+          <RendererSelect />
+        </div>
+      {/if}
+      <div class="custom-url-input">
+        <CustomUrlInput
+          on:styleload={handleCustomUrl}
+          activeStyle={style}
+          disabled={isLoading && loadingProgress !== null}
+        />
+      </div>
     </div>
   </div>
   {#if expandedLayers.length}
@@ -277,5 +285,19 @@
     top: calc(36px + (var(--app-padding) * 2));
     right: 0px;
     margin: 36px;
+  }
+
+  .right-side-container {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .renderer-switch-container {
+    margin-right: 12px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,8 @@
 <script>
   import * as d3 from 'd3';
-  import { migrate } from '@mapbox/mapbox-gl-style-spec';
+  import { migrate as migrateMapbox } from '@mapbox/mapbox-gl-style-spec';
+  import { migrate as migrateMaplibre } from '@maplibre/maplibre-gl-style-spec';
+
   import { onMount } from 'svelte';
   import Fa from 'svelte-fa/src/fa.svelte';
   import { faTrash, faDownload } from '@fortawesome/free-solid-svg-icons';
@@ -98,7 +100,18 @@
   }
 
   function setStyle(nextStyle) {
-    style = migrate(nextStyle);
+    // try to migrate w/ Mapbox, then try with MapLibre if that fails
+    try {
+      style = migrateMapbox(nextStyle);
+    } catch (e) {
+      try {
+        style = migrateMaplibre(nextStyle);
+      } catch (err) {
+        console.warn(e);
+        console.warn(err);
+      }
+    }
+
     style = convertStylesheetToRgb(style);
     // On dropping in a style, switch to the fill tab to refresh background layer state
     handleTabChange({ detail: { tab: 'fill' } });

--- a/src/CustomUrlInput.svelte
+++ b/src/CustomUrlInput.svelte
@@ -150,7 +150,6 @@
 
 <style>
   .map-style-input {
-    margin-top: 6px;
     display: flex;
   }
 

--- a/src/RendererSelect.svelte
+++ b/src/RendererSelect.svelte
@@ -1,26 +1,91 @@
 <script>
   import { renderers } from './constants';
-  import { rendererStore } from './stores';
+  import { rendererStore, styleStore } from './stores';
+  import Fa from 'svelte-fa/src/fa.svelte';
+  import { faCircle } from '@fortawesome/free-solid-svg-icons';
+  import { validate as validateMapbox } from '@mapbox/mapbox-gl-style-spec';
+  import { validate as validateMaplibre } from '@maplibre/maplibre-gl-style-spec';
 
   let selectedRenderer;
+  let style;
+  let errors = [];
+
+  styleStore.subscribe(value => (style = value));
+
+  const getBetterErrorMessages = errors => {
+    return errors.map(error => {
+      let { message } = error;
+      // Replace layers[<index>] with layerId
+      const replaceRegex = /layers\[\d+\]\./g;
+      // Remove layers[<index>] following this pattern since it already shows layer id
+      const removeRegex = /layers\[\d+\]: /g;
+      function replacer(match, str) {
+        let num = match.match(/\d+/g);
+        let layerId;
+        if (num && !isNaN(Number(num))) {
+          layerId = style?.layers[Number(num)]?.id;
+        }
+        return layerId ? `layer "${layerId}" ` : match + str;
+      }
+      message = message
+        .replace(replaceRegex, replacer)
+        .replace(removeRegex, '');
+      return message;
+    });
+  };
 
   const setRenderer = renderer => {
     rendererStore.set(renderer);
+    if (style) {
+      if (renderer === 'mapbox-gl') {
+        errors = validateMapbox(JSON.stringify(style));
+      } else {
+        errors = validateMaplibre(JSON.stringify(style));
+      }
+      errors = getBetterErrorMessages(errors);
+    }
   };
 
   $: setRenderer(selectedRenderer);
 </script>
 
-<div>
-  Renderer:
+<div class="container">
+  <div class="label">
+    <div />
+    Renderer:
+    <div
+      class="icon"
+      title={errors ? errors.map(e => `• ${e}`).join('\n\n') : ''}
+    >
+      <Fa icon={faCircle} color={errors.length ? 'red' : 'green'} />
+    </div>
+  </div>
+
   <select class="renderer-dropdown" bind:value={selectedRenderer}>
     {#each renderers as renderer}
-      <option value={renderer.value}>{renderer.name}</option>
+      <option value={renderer.value}> {renderer.name}</option>
     {/each}
   </select>
 </div>
 
 <style>
+  .container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .icon {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+
+  .label {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
   .renderer-dropdown {
     height: 30px;
     font-size: 12px;

--- a/src/RendererSelect.svelte
+++ b/src/RendererSelect.svelte
@@ -1,0 +1,28 @@
+<script>
+  import { renderers } from './constants';
+  import { rendererStore } from './stores';
+
+  let selectedRenderer;
+
+  const setRenderer = renderer => {
+    rendererStore.set(renderer);
+  };
+
+  $: setRenderer(selectedRenderer);
+</script>
+
+<div>
+  Renderer:
+  <select class="renderer-dropdown" bind:value={selectedRenderer}>
+    {#each renderers as renderer}
+      <option value={renderer.value}>{renderer.name}</option>
+    {/each}
+  </select>
+</div>
+
+<style>
+  .renderer-dropdown {
+    height: 30px;
+    font-size: 12px;
+  }
+</style>

--- a/src/TabsContent.svelte
+++ b/src/TabsContent.svelte
@@ -2,11 +2,15 @@
   import FillsChart from './FillsChart.svelte';
   import LinesChart from './LinesChart.svelte';
   import TypographyChart from './TypographyChart.svelte';
+  import { rendererStore } from './stores';
 
   export let selectedTab;
   export let style;
   export let updateBackgroundRect;
   export let backgroundSvgData;
+
+  let rendererLib;
+  rendererStore.subscribe(value => (rendererLib = value));
 </script>
 
 <div class="tabs-content">
@@ -15,7 +19,9 @@
   {:else if selectedTab === 'lines'}
     <LinesChart {style} />
   {:else if selectedTab === 'typography'}
-    <TypographyChart {style} />
+    {#key rendererLib}
+      <TypographyChart {style} {rendererLib} />
+    {/key}
   {/if}
 </div>
 

--- a/src/TypographyChart.svelte
+++ b/src/TypographyChart.svelte
@@ -1,7 +1,6 @@
 <script>
   import * as d3 from 'd3';
   import { onMount } from 'svelte';
-  import mapboxGl from 'mapbox-gl';
   import { getValue as getInterpolatedValue } from './interpolation';
   import Tooltip from './Tooltip.svelte';
   import { displayLayersStore } from './stores';
@@ -9,6 +8,7 @@
   export let style;
   export let minZoom = 0;
   export let maxZoom = 24;
+  export let rendererLib;
 
   let map;
 
@@ -25,6 +25,18 @@
   let layers;
   let xAxisFont;
   let zooms = d3.range(minZoom, maxZoom + 1, 2);
+
+  let renderer;
+  // Mapbox and MapLibre share a Map component since they are so similar and utilize the same methods
+  const importRenderer = async () => {
+    if (rendererLib === 'maplibre-gl') {
+      await import('maplibre-gl/dist/maplibre-gl.css');
+      renderer = await import('maplibre-gl');
+    } else {
+      await import('mapbox-gl/dist/mapbox-gl.css');
+      renderer = await import('mapbox-gl');
+    }
+  };
 
   const handleTooltipClose = () => {
     selectedLayerId = null;
@@ -355,7 +367,7 @@
   }
 
   function createMap(style) {
-    map = new mapboxGl.Map({
+    map = new renderer.Map({
       container: 'map',
       style: {
         version: 8,
@@ -399,7 +411,8 @@
     if (map && map.isStyleLoaded()) draw();
   }
 
-  onMount(() => {
+  onMount(async () => {
+    await importRenderer();
     createMap(style);
   });
 </script>

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,13 @@ export let MARGIN = {
   top: 25,
 };
 export const DISPLAY_CHUNK_SIZE = 100;
+export const renderers = [
+  {
+    name: 'Mapbox GL',
+    value: 'mapbox-gl',
+  },
+  {
+    name: 'Maplibre GL',
+    value: 'maplibre-gl',
+  },
+];

--- a/src/stores.js
+++ b/src/stores.js
@@ -30,3 +30,5 @@ export const svgStoreInitialState = {
   },
 };
 export const svgStore = writable(svgStoreInitialState);
+
+export let rendererStore = writable('mapbox-gl');

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,5 +1,7 @@
 import { writable } from 'svelte/store';
 
+export const styleStore = writable(null);
+
 export const propertyValueComboLimitStore = writable(10);
 
 export const loadingStore = writable({ loading: false, progress: null });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,7 +1169,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@mapbox/geojson-rewind@^0.5.0":
+"@mapbox/geojson-rewind@^0.5.0", "@mapbox/geojson-rewind@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz#591a5d71a9cd1da1a0bf3420b3bea31b0fc7946a"
   integrity sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==
@@ -1206,6 +1206,11 @@
   resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz#f60b6a55a5d8e5ee908347d2ce4250b15103dc8e"
   integrity sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==
 
+"@mapbox/mapbox-gl-supported@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz#c15367178d8bfe4765e6b47b542fe821ce259c7b"
+  integrity sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==
+
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
@@ -1216,10 +1221,20 @@
   resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz#424c620a96442b20402552be70a7f62a8407cc59"
   integrity sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==
 
+"@mapbox/tiny-sdf@^2.0.5":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz#9a1d33e5018093e88f6a4df2343e886056287282"
+  integrity sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==
+
 "@mapbox/unitbezier@^0.0.0":
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz#15651bd553a67b8581fb398810c98ad86a34524e"
   integrity sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==
+
+"@mapbox/unitbezier@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz#d32deb66c7177e9e9dfc3bbd697083e2e657ff01"
+  integrity sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==
 
 "@mapbox/vector-tile@^1.3.1":
   version "1.3.1"
@@ -1232,6 +1247,19 @@
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
+
+"@maplibre/maplibre-gl-style-spec@^17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-17.0.2.tgz#af738fdb355a2b5ad3fc2fb2d73dbe56450b1996"
+  integrity sha512-iW63wG/ZzeJ2PawkR2g2m4VnFYlUJW22Uu966YhR6K0nDJflDE6QBLanX4wsfZb6adLT6Z106N/apgWKvS2/8g==
+  dependencies:
+    "@mapbox/jsonlint-lines-primitives" "~2.0.2"
+    "@mapbox/unitbezier" "^0.0.0"
+    csscolorparser "~1.0.2"
+    json-stringify-pretty-compact "^2.0.0"
+    minimist "^1.2.5"
+    rw "^1.3.3"
+    sort-object "^0.3.2"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -1388,6 +1416,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/geojson@*", "@types/geojson@^7946.0.10":
+  version "7946.0.10"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
+  integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1414,6 +1447,20 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/mapbox__point-geometry@*", "@types/mapbox__point-geometry@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz#488a9b76e8457d6792ea2504cdd4ecdd9860a27e"
+  integrity sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==
+
+"@types/mapbox__vector-tile@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz#8fa1379dbaead1e1b639b8d96cfd174404c379d6"
+  integrity sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==
+  dependencies:
+    "@types/geojson" "*"
+    "@types/mapbox__point-geometry" "*"
+    "@types/pbf" "*"
+
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -1428,6 +1475,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/pbf@*", "@types/pbf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/pbf/-/pbf-3.0.2.tgz#8d291ad68b4b8c533e96c174a2e3e6399a59ed61"
+  integrity sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==
 
 "@types/prettier@^2.1.5":
   version "2.6.3"
@@ -2457,7 +2509,7 @@ domutils@^2.8.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
-earcut@^2.2.2:
+earcut@^2.2.2, earcut@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
   integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
@@ -2774,7 +2826,7 @@ gh-pages@^3.2.3:
     fs-extra "^8.1.0"
     globby "^6.1.0"
 
-gl-matrix@^3.2.1:
+gl-matrix@^3.2.1, gl-matrix@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.3.tgz#fc1191e8320009fd4d20e9339595c6041ddc22c9"
   integrity sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==
@@ -2797,6 +2849,15 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-3.0.0.tgz#fc85f73064df69f50421f47f883fe5b913ba9b97"
+  integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
+  dependencies:
+    ini "^1.3.5"
+    kind-of "^6.0.2"
+    which "^1.3.1"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -2959,6 +3020,11 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@^1.3.5:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 "internmap@1 - 2":
   version "2.0.3"
@@ -3596,6 +3662,11 @@ kdbush@^3.0.0:
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
   integrity sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==
 
+kind-of@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
 kleur@^3.0.0, kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -3761,6 +3832,36 @@ mapbox-gl@^1.13.2:
     supercluster "^7.1.0"
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.1"
+
+maplibre-gl@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-2.4.0.tgz#2b53dbf526626bf4ee92ad4f33f13ef09e5af182"
+  integrity sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==
+  dependencies:
+    "@mapbox/geojson-rewind" "^0.5.2"
+    "@mapbox/jsonlint-lines-primitives" "^2.0.2"
+    "@mapbox/mapbox-gl-supported" "^2.0.1"
+    "@mapbox/point-geometry" "^0.1.0"
+    "@mapbox/tiny-sdf" "^2.0.5"
+    "@mapbox/unitbezier" "^0.0.1"
+    "@mapbox/vector-tile" "^1.3.1"
+    "@mapbox/whoots-js" "^3.1.0"
+    "@types/geojson" "^7946.0.10"
+    "@types/mapbox__point-geometry" "^0.1.2"
+    "@types/mapbox__vector-tile" "^1.3.0"
+    "@types/pbf" "^3.0.2"
+    csscolorparser "~1.0.3"
+    earcut "^2.2.4"
+    geojson-vt "^3.2.1"
+    gl-matrix "^3.4.3"
+    global-prefix "^3.0.0"
+    murmurhash-js "^1.0.0"
+    pbf "^3.2.1"
+    potpack "^1.0.2"
+    quickselect "^2.0.0"
+    supercluster "^7.1.5"
+    tinyqueue "^2.0.3"
+    vt-pbf "^3.1.3"
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -4325,7 +4426,7 @@ postcss@^8.4.5:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-potpack@^1.0.1:
+potpack@^1.0.1, potpack@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/potpack/-/potpack-1.0.2.tgz#23b99e64eb74f5741ffe7656b5b5c4ddce8dfc14"
   integrity sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==
@@ -4854,7 +4955,7 @@ stylehacks@^5.1.0:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
 
-supercluster@^7.1.0:
+supercluster@^7.1.0, supercluster@^7.1.5:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.5.tgz#65a6ce4a037a972767740614c19051b64b8be5a3"
   integrity sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==
@@ -5112,7 +5213,7 @@ v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
-vt-pbf@^3.1.1:
+vt-pbf@^3.1.1, vt-pbf@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.1.3.tgz#68fd150756465e2edae1cc5c048e063916dcfaac"
   integrity sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==
@@ -5172,6 +5273,13 @@ whatwg-url@^8.0.0, whatwg-url@^8.5.0:
     lodash "^4.7.0"
     tr46 "^2.1.0"
     webidl-conversions "^6.1.0"
+
+which@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
 
 which@^2.0.1:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,10 +1248,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@maplibre/maplibre-gl-style-spec@^17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-17.0.2.tgz#af738fdb355a2b5ad3fc2fb2d73dbe56450b1996"
-  integrity sha512-iW63wG/ZzeJ2PawkR2g2m4VnFYlUJW22Uu966YhR6K0nDJflDE6QBLanX4wsfZb6adLT6Z106N/apgWKvS2/8g==
+"@maplibre/maplibre-gl-style-spec@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-16.0.0.tgz#07ecee35ada4fa91b9fe577b2ff1a2664b48e50d"
+  integrity sha512-dmQpNTNCIk+gak64KbugZ3wvInYk6fS+PW6em2LIgYY/kTbraLYMt/McqDM/AKgpGpJTQuMHAKksO4/d+EUwOw==
   dependencies:
     "@mapbox/jsonlint-lines-primitives" "~2.0.2"
     "@mapbox/unitbezier" "^0.0.0"


### PR DESCRIPTION
Closes #53

Straight forward implementation of a switch in the typography chart to switch between Maplibre and Mapbox rendering.

The only additional thing I had to add in here was updating where we migrate a style to try migrating from the Mapbox style spec, then try the Maplibre style spec if that doesn't work (due to a property only available in Maplibre).

I added very light validation to expose errors in the form of a red or green circle by the dropdown. Hovering that shows the errors with a "title" property. Not sure if this is something we want to expand upon or keep at all.