### PR TITLE
Prompt for Mapbox token if needed

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -88,6 +88,10 @@
     style = await d3.json(url);
   }
 
+  function revertTab() {
+    handleTabChange({ detail: { tab: 'fill' } });
+  }
+
   function handleTabChange(e) {
     selectedTab = e.detail.tab;
     updateQuery();
@@ -130,6 +134,8 @@
 
   function clearStyle() {
     style = undefined;
+    displayLayersStore.set(displayLayersStoreInitialState);
+    svgStore.set(svgStoreInitialState);
   }
 
   function downloadSvg() {
@@ -193,7 +199,7 @@
       <div />
     {/if}
     <div class="right-side-container">
-      {#if selectedTab === 'typography'}
+      {#if selectedTab === 'typography' && style}
         <div class="renderer-switch-container">
           <RendererSelect />
         </div>
@@ -208,7 +214,7 @@
     </div>
   </div>
   {#if expandedLayers.length}
-    <TabsContent {selectedTab} {style} />
+    <TabsContent {selectedTab} {style} on:revertPage={revertTab} />
     <button class="clear-style-button" on:click={clearStyle}
       >Clear style <div class="icon"><Fa icon={faTrash} /></div></button
     >

--- a/src/RendererSelect.svelte
+++ b/src/RendererSelect.svelte
@@ -5,7 +5,9 @@
   import { faCircle } from '@fortawesome/free-solid-svg-icons';
   import { validate as validateMapbox } from '@mapbox/mapbox-gl-style-spec';
   import { validate as validateMaplibre } from '@maplibre/maplibre-gl-style-spec';
+  import { isAccessTokenRequired } from './is-access-token-required';
 
+  let displayRenderers = renderers;
   let selectedRenderer;
   let style;
   let errors = [];
@@ -47,6 +49,13 @@
   };
 
   $: setRenderer(selectedRenderer);
+
+  $: if (style) {
+    const mapboxOnly = isAccessTokenRequired(style);
+    if (mapboxOnly) {
+      displayRenderers = displayRenderers.filter(v => v.value === 'mapbox-gl');
+    }
+  }
 </script>
 
 <div class="container">
@@ -62,7 +71,7 @@
   </div>
 
   <select class="renderer-dropdown" bind:value={selectedRenderer}>
-    {#each renderers as renderer}
+    {#each displayRenderers as renderer}
       <option value={renderer.value}> {renderer.name}</option>
     {/each}
   </select>

--- a/src/TabsContent.svelte
+++ b/src/TabsContent.svelte
@@ -20,7 +20,7 @@
     <LinesChart {style} />
   {:else if selectedTab === 'typography'}
     {#key rendererLib}
-      <TypographyChart {style} {rendererLib} />
+      <TypographyChart {style} {rendererLib} on:revertPage />
     {/key}
   {/if}
 </div>

--- a/src/is-access-token-required.js
+++ b/src/is-access-token-required.js
@@ -1,0 +1,23 @@
+const isMapboxUrl = url => {
+  if (typeof url !== 'string') return false;
+  const hasMapboxFormat = url.startsWith('mapbox://');
+  return hasMapboxFormat;
+};
+
+const isAccessTokenRequired = style => {
+  const { sprite, glyphs, sources } = style;
+
+  const hasMapboxSourceUrls = !!Object.values(sources)
+    .reduce((acc, s) => {
+      if (s.url) return acc.concat(s.url);
+      if (s.tiles) return acc.concat(s.tiles);
+    }, [])
+    .filter(isMapboxUrl).length;
+
+  const usesMapboxUrls =
+    isMapboxUrl(sprite) || isMapboxUrl(glyphs) || hasMapboxSourceUrls;
+
+  return usesMapboxUrls;
+};
+
+export { isAccessTokenRequired };

--- a/src/stores.js
+++ b/src/stores.js
@@ -34,3 +34,5 @@ export const svgStoreInitialState = {
 export const svgStore = writable(svgStoreInitialState);
 
 export let rendererStore = writable('mapbox-gl');
+
+export const mapboxGlAccessTokenStore = writable('');


### PR DESCRIPTION
Closes https://github.com/stamen/chartographer/issues/57

Prompts for a Mapbox token if needed for the typography chart.

### QA
#### A
- [ ] Use style with Mapbox URLs for source, sprite, and/or glyphs (I just used Mapbox Streets)
- [ ] Switch to typography chart
- [ ] Expect to be prompted for Mapbox token
- [ ] Enter **incorrect** token without `pk.` at beginning
- [ ] Expect warning that tokens must start with `pk.`
- [ ] When prompted again, enter **incorrect** token _with_ `pk.` at beginning
- [ ] Expect warning that token is invalid
- [ ] When prompted again, cancel the box
- [ ] Expect warning and redirect to `fill` page
- [ ] Click typography page again
- [ ] When prompted again enter correct token
- [ ] Expect that typography chart works
- [ ] Expect that renderer dropdown only allows Mapbox due to Mapbox URLs
- [ ] Change or clear style
- [ ] Add back previous style or another style requiring a token
- [ ] Switch back to typography chart
- [ ] Expect no prompt since you've added a token in this session

#### B
- [ ] Add a style that does not require a Mapbox token
- [ ] Expect no prompt