### PR TITLE
Update link to OSM Americana repository

### DIFF
--- a/example-styles/README.md
+++ b/example-styles/README.md
@@ -3,4 +3,4 @@
 These are example styles for testing purposes. They are not part of chartographer. Please see their respective repos for licensing.
 
 - [osm-liberty](https://github.com/maputnik/osm-liberty)
-- [openstreetmap-americana](https://github.com/ZeLonewolf/openstreetmap-americana)
+- [openstreetmap-americana](https://github.com/osm-americana/openstreetmap-americana)


### PR DESCRIPTION
Updated a link to the OpenStreetMap Americana repository that broke following osm-americana/openstreetmap-americana#1187.