### PR TITLE
Return acc by default if url or tiles not found

### DIFF
--- a/src/is-access-token-required.js
+++ b/src/is-access-token-required.js
@@ -11,6 +11,7 @@ const isAccessTokenRequired = style => {
     .reduce((acc, s) => {
       if (s.url) return acc.concat(s.url);
       if (s.tiles) return acc.concat(s.tiles);
+      return acc;
     }, [])
     .filter(isMapboxUrl).length;
 


### PR DESCRIPTION
This was causing some issues with loading a style that contained GeoJSON layers.