### PR TITLE
[WIP] Fix line-width step error

### DIFF
--- a/src/LinesChart.svelte
+++ b/src/LinesChart.svelte
@@ -88,15 +88,13 @@
     let path;
 
     if (Array.isArray(width)) {
-      const [
-        expressionType,
-        [interpolationType, interpolationBase],
-        [attribute],
-      ] = width;
+      let [expressionType, [interpolationType, interpolationBase], attribute] =
+        width;
       if (
         expressionType === 'interpolate' &&
         interpolationType === 'linear' &&
-        attribute === 'zoom'
+        Array.isArray(attribute) &&
+        attribute[0] === 'zoom'
       ) {
         // TODO look into base for interpolation
 


### PR DESCRIPTION
Closes https://github.com/stamen/chartographer/issues/70

This PR just prevents the error we were getting for `step` functions within the `line-width` property.

It does not support this property appropriately still. Looking at the code, I'm debating whether it's worth fixing cases like this individually or if we should consider a [holistic rebuilding of the application's approach](https://github.com/stamen/chartographer/issues/76).

Will update this PR with more soon.